### PR TITLE
fix(lint,security): resolve CI failures and supersede PR #23

### DIFF
--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -10,6 +10,11 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 env:
   ANSIBLE_FORCE_COLOR: 1
   PYTEST_ADDOPTS: --color=yes

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ check-test-prereqs:
 	@echo "$(BLUE)Checking test prerequisites...$(NC)"
 	@command -v docker >/dev/null 2>&1 || { echo "$(RED)Error: Docker is not installed$(NC)"; exit 1; }
 	@docker info >/dev/null 2>&1 || { echo "$(RED)Error: Docker is not running$(NC)"; exit 1; }
-	@command -v docker-compose >/dev/null 2>&1 || { echo "$(RED)Error: docker-compose is not installed$(NC)"; exit 1; }
+	@command -v docker-compose >/dev/null 2>&1 || docker compose version >/dev/null 2>&1 || { echo "$(RED)Error: docker-compose is not installed$(NC)"; exit 1; }
 	@command -v jq >/dev/null 2>&1 || { echo "$(RED)Error: jq is not installed (brew install jq)$(NC)"; exit 1; }
 	@test -f docker-compose.test.yml || { echo "$(RED)Error: docker-compose.test.yml not found$(NC)"; exit 1; }
 	@echo "$(GREEN)✅ All test prerequisites are met$(NC)"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,9 @@ wordpress_site_url: "https://{{ ansible_fqdn }}"
 wordpress_site_title: "Enterprise WordPress Site"
 
 # WordPress admin user
+# NOTE: For production, override passwords in group_vars or use ansible-vault
+# The /dev/null lookup generates a new password each run (not idempotent).
+# For idempotent passwords, use: lookup('password', 'credentials/admin_password length=32')
 wordpress_admin_user: "wpadmin"
 wordpress_admin_password: "{{ lookup('password', '/dev/null length=32 chars=ascii_letters,digits') }}"
 wordpress_admin_email: "admin@{{ ansible_domain | default('example.com') }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,8 @@
 ---
 # Handlers for ansible-wordpress-enterprise
+# NOTE: Each handler should only be defined once to avoid unexpected behavior
 
+# PHP-FPM Handlers
 - name: Restart php-fpm
   ansible.builtin.systemd:
     name: "{{ wordpress_php_fpm_service }}"
@@ -8,6 +10,21 @@
     daemon_reload: true
   become: true
 
+- name: Restart php8.1-fpm
+  ansible.builtin.systemd:
+    name: php8.1-fpm
+    state: restarted
+    daemon_reload: true
+  become: true
+
+- name: Restart php8.2-fpm
+  ansible.builtin.systemd:
+    name: php8.2-fpm
+    state: restarted
+    daemon_reload: true
+  become: true
+
+# Nginx Handlers
 - name: Reload nginx
   ansible.builtin.systemd:
     name: nginx
@@ -20,30 +37,33 @@
     state: restarted
   become: true
 
+# Apache Handlers
 - name: Reload apache
   ansible.builtin.systemd:
-    name: "{{ wordpress_apache_service }}"
+    name: "{{ wordpress_apache_service | default('apache2') }}"
     state: reloaded
   become: true
 
 - name: Restart apache
   ansible.builtin.systemd:
-    name: "{{ wordpress_apache_service }}"
+    name: "{{ wordpress_apache_service | default('apache2') }}"
     state: restarted
   become: true
 
+# Database Handlers
 - name: Restart mysql
   ansible.builtin.systemd:
-    name: "{{ wordpress_mysql_service }}"
+    name: "{{ wordpress_mysql_service | default('mysql') }}"
     state: restarted
   become: true
 
 - name: Restart mariadb
   ansible.builtin.systemd:
-    name: "{{ wordpress_mariadb_service }}"
+    name: "{{ wordpress_mariadb_service | default('mariadb') }}"
     state: restarted
   become: true
 
+# Cache Handlers
 - name: Restart redis
   ansible.builtin.systemd:
     name: redis
@@ -56,6 +76,7 @@
     state: restarted
   become: true
 
+# Security Handlers
 - name: Restart fail2ban
   ansible.builtin.systemd:
     name: fail2ban
@@ -68,88 +89,6 @@
     state: reloaded
   become: true
 
-- name: Restart php-fpm
-  ansible.builtin.systemd:
-    name: "{{ wordpress_php_fpm_service }}"
-    state: restarted
-  become: true
-
-- name: Reload nginx
-  ansible.builtin.systemd:
-    name: nginx
-    state: reloaded
-  become: true
-
-- name: Reload apache
-  ansible.builtin.systemd:
-    name: "{{ wordpress_apache_service }}"
-    state: reloaded
-  become: true
-
-- name: Restart apache
-  ansible.builtin.systemd:
-    name: "{{ wordpress_apache_service }}"
-    state: restarted
-  become: true
-
-- name: Restart redis
-  ansible.builtin.systemd:
-    name: redis
-    state: restarted
-  become: true
-
-- name: Restart fail2ban
-  ansible.builtin.systemd:
-    name: fail2ban
-    state: restarted
-  become: true
-
-- name: "Reload nginx"
-  ansible.builtin.systemd:
-    name: nginx
-    state: reloaded
-  become: true
-
-- name: "Reload apache"
-  ansible.builtin.systemd:
-    name: "{{ wordpress_apache_service }}"
-    state: reloaded
-  become: true
-
-- name: "Restart mysql"
-  ansible.builtin.systemd:
-    name: mysql
-    state: restarted
-  become: true
-
-- name: "Restart mariadb"
-  ansible.builtin.systemd:
-    name: mariadb
-    state: restarted
-  become: true
-
-- name: "Restart php8.1-fpm"
-  ansible.builtin.systemd:
-    name: php8.1-fpm
-    state: restarted
-    daemon_reload: true
-  become: true
-
-- name: "Restart php8.2-fpm"
-  ansible.builtin.systemd:
-    name: php8.2-fpm
-    state: restarted
-    daemon_reload: true
-  become: true
-
-- name: restart php-fpm
-  ansible.builtin.systemd:
-    name: "{{ wordpress_php_fpm_service }}"
-    state: restarted
-    daemon_reload: true
-  become: true
-
-# Security-related handlers
 - name: reload apparmor
   ansible.builtin.systemd:
     name: apparmor
@@ -171,6 +110,7 @@
   become: true
   when: ansible_os_family == "RedHat"
 
+# System Handlers
 - name: reboot system
   ansible.builtin.reboot:
     reboot_timeout: 600

--- a/simple-test.yml
+++ b/simple-test.yml
@@ -69,28 +69,28 @@
 
   tasks:
     - name: Test external service connectivity
-      wait_for:
+      ansible.builtin.wait_for:
         host: "{{ wordpress_db_host }}"
         port: "{{ wordpress_db_port }}"
         timeout: 30
 
     - name: Include prerequisites only
-      include_tasks: tasks/prerequisites.yml
+      ansible.builtin.include_tasks: tasks/prerequisites.yml
 
     - name: Include PHP installation
-      include_tasks: tasks/php.yml
+      ansible.builtin.include_tasks: tasks/php.yml
 
     - name: Include web server installation
-      include_tasks: tasks/webserver_nginx.yml
+      ansible.builtin.include_tasks: tasks/webserver_nginx.yml
 
     - name: Include WordPress installation
-      include_tasks: tasks/wordpress_install.yml
+      ansible.builtin.include_tasks: tasks/wordpress_install.yml
 
     - name: Include WordPress configuration
-      include_tasks: tasks/wordpress_configure.yml
+      ansible.builtin.include_tasks: tasks/wordpress_configure.yml
 
     - name: Display installation info
-      debug:
+      ansible.builtin.debug:
         msg:
           - "WordPress installation test completed!"
           - "Site URL: {{ wordpress_site_url }}"

--- a/tasks/database.yml
+++ b/tasks/database.yml
@@ -32,6 +32,7 @@
     - wordpress_db_root_password is defined
   register: mysql_root_password_set
   failed_when: false
+  no_log: true
 
 - name: Create MySQL root configuration file
   ansible.builtin.template:
@@ -52,6 +53,7 @@
     login_password: "{{ wordpress_db_root_password }}"
   become: true
   when: not wordpress_use_external_db | bool
+  no_log: true
 
 - name: Remove MySQL test database
   community.mysql.mysql_db:
@@ -61,6 +63,7 @@
     login_password: "{{ wordpress_db_root_password }}"
   become: true
   when: not wordpress_use_external_db | bool
+  no_log: true
 
 - name: Remove remote root user access
   community.mysql.mysql_user:
@@ -79,6 +82,7 @@
     - not wordpress_use_external_db | bool
     - item != "localhost"
   failed_when: false
+  no_log: true
 
 - name: Create WordPress database
   community.mysql.mysql_db:
@@ -89,6 +93,7 @@
     login_user: root
     login_password: "{{ wordpress_db_root_password }}"
   become: true
+  no_log: true
 
 - name: Create WordPress database user
   community.mysql.mysql_user:
@@ -100,6 +105,7 @@
     login_user: root
     login_password: "{{ wordpress_db_root_password }}"
   become: true
+  no_log: true
 
 - name: Configure MySQL/MariaDB for WordPress
   ansible.builtin.template:
@@ -181,6 +187,7 @@
     login_password: "{{ wordpress_db_root_password }}"
   become: true
   when: not wordpress_use_external_db | bool
+  no_log: true
 
 - name: Test database connection
   community.mysql.mysql_query:
@@ -192,6 +199,7 @@
     login_db: "{{ wordpress_db_name }}"
   register: db_connection_test
   changed_when: false
+  no_log: true
 
 - name: Display database connection status
   ansible.builtin.debug:
@@ -210,6 +218,7 @@
   when:
     - not wordpress_use_external_db | bool
     - wordpress_enable_logging | bool
+  no_log: true
 
 - name: Configure external database SSL (if enabled)
   when:

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -63,7 +63,7 @@
 
 - name: Allow SSH access (firewalld)
   ansible.posix.firewalld:
-    service: ssh
+    ansible.builtin.service: ssh
     permanent: true
     state: enabled
     immediate: true
@@ -84,7 +84,7 @@
 
 - name: Allow HTTP traffic (firewalld)
   ansible.posix.firewalld:
-    service: "{{ wordpress_firewall_http_service }}"
+    ansible.builtin.service: "{{ wordpress_firewall_http_service }}"
     permanent: true
     state: enabled
     immediate: true
@@ -106,7 +106,7 @@
 
 - name: Allow HTTPS traffic (firewalld)
   ansible.posix.firewalld:
-    service: "{{ wordpress_firewall_https_service }}"
+    ansible.builtin.service: "{{ wordpress_firewall_https_service }}"
     permanent: true
     state: enabled
     immediate: true

--- a/tasks/prerequisites.yml
+++ b/tasks/prerequisites.yml
@@ -42,7 +42,7 @@
   ansible.builtin.user:
     name: "{{ wordpress_system_user | default('www-data') }}"
     system: true
-    shell: /bin/false
+    ansible.builtin.shell: /bin/false
     home: /var/www
     createhome: true
     state: present

--- a/tasks/security_hardening.yml
+++ b/tasks/security_hardening.yml
@@ -186,6 +186,8 @@
         - wordpress_install_security_tools | default(true)
 
     - name: Configure automatic security updates
+      become: true
+      when: wordpress_auto_security_updates | default(true)
       block:
         - name: Install unattended-upgrades (Debian/Ubuntu)
           ansible.builtin.package:
@@ -216,10 +218,9 @@
           when: ansible_os_family == "RedHat"
           notify:
             - restart yum-cron
-      become: true
-      when: wordpress_auto_security_updates | default(true)
 
     - name: Configure system-wide security settings
+      become: true
       block:
         - name: Disable unused network services
           ansible.builtin.systemd:
@@ -284,7 +285,6 @@
               value: '7'
           become: true
           when: wordpress_password_policy | default(true)
-      become: true
 
 - name: Generate security status report
   ansible.builtin.template:
@@ -376,6 +376,7 @@
       Run 'wordpress-security-status' to check current security status.
 
 - name: Validate security configuration
+  when: wordpress_security_validate | default(true)
   block:
     - name: Test file permissions
       ansible.builtin.stat:
@@ -405,4 +406,3 @@
           wp-config.php permissions: {{ wp_config_perms.stat.mode if wp_config_perms.stat.exists else 'File not found' }}
           uploads directory permissions: {{ wp_uploads_perms.stat.mode if wp_uploads_perms.stat.exists else 'Directory not found' }}
           Security services status: {{ security_services.results | map(attribute='status') | map(attribute='ActiveState') | join(', ') }}
-  when: wordpress_security_validate | default(true)

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -193,6 +193,10 @@
   become: true
 
 - name: Create custom SELinux policy for WordPress (if needed)
+  when:
+    - ansible_os_family == "RedHat"
+    - selinux_enabled | default(false)
+    - wordpress_selinux_custom_policy | default(false)
   block:
     - name: Create custom SELinux policy directory
       ansible.builtin.file:
@@ -239,12 +243,12 @@
       when: selinux_policy_file.changed
       become: true
       changed_when: true
+
+- name: Set up SELinux logging and monitoring
   when:
     - ansible_os_family == "RedHat"
     - selinux_enabled | default(false)
-    - wordpress_selinux_custom_policy | default(false)
-
-- name: Set up SELinux logging and monitoring
+    - wordpress_selinux_audit | default(true)
   block:
     - name: Install audit daemon
       ansible.builtin.package:
@@ -273,10 +277,6 @@
         enabled: true
         state: started
       become: true
-  when:
-    - ansible_os_family == "RedHat"
-    - selinux_enabled | default(false)
-    - wordpress_selinux_audit | default(true)
 
 - name: Generate SELinux troubleshooting script
   ansible.builtin.template:
@@ -312,6 +312,10 @@
   become: true
 
 - name: Validate SELinux configuration
+  when:
+    - ansible_os_family == "RedHat"
+    - selinux_enabled | default(false)
+    - wordpress_selinux_validate | default(true)
   block:
     - name: Check SELinux contexts are applied correctly
       ansible.builtin.command: ls -laZ {{ wordpress_path }}
@@ -332,7 +336,3 @@
         msg: |
           SELinux contexts: {{ selinux_contexts.stdout_lines[:5] }}
           SELinux booleans: {{ selinux_booleans.results | map(attribute='stdout') | list }}
-  when:
-    - ansible_os_family == "RedHat"
-    - selinux_enabled | default(false)
-    - wordpress_selinux_validate | default(true)

--- a/tasks/wordpress_install.yml
+++ b/tasks/wordpress_install.yml
@@ -6,7 +6,7 @@
     name: "{{ wordpress_system_user }}"
     group: "{{ wordpress_system_group }}"
     system: true
-    shell: /bin/bash
+    ansible.builtin.shell: /bin/bash
     home: "{{ wordpress_install_dir }}"
     create_home: false
     state: present

--- a/test-1-prerequisites.yml
+++ b/test-1-prerequisites.yml
@@ -14,10 +14,10 @@
 
   tasks:
     - name: Test Prerequisites Installation
-      include_tasks: tasks/prerequisites.yml
+      ansible.builtin.include_tasks: tasks/prerequisites.yml
 
     - name: Verify basic packages are installed
-      command: which {{ item }}
+      ansible.builtin.command: which {{ item }}
       loop:
         - curl
         - wget
@@ -27,7 +27,7 @@
       changed_when: false
 
     - name: Display test results
-      debug:
+      ansible.builtin.debug:
         msg:
           - "✅ Prerequisites test completed successfully!"
           - "✅ All basic packages are installed"

--- a/test-2-php-simple.yml
+++ b/test-2-php-simple.yml
@@ -15,10 +15,10 @@
 
   tasks:
     - name: Install Prerequisites
-      include_tasks: tasks/prerequisites.yml
+      ansible.builtin.include_tasks: tasks/prerequisites.yml
 
     - name: Install PHP packages
-      apt:
+      ansible.builtin.apt:
         name:
           - "php{{ wordpress_php_version }}"
           - "php{{ wordpress_php_version }}-fpm"
@@ -37,25 +37,25 @@
         update_cache: true
 
     - name: Enable and start PHP-FPM service
-      systemd:
+      ansible.builtin.systemd:
         name: "php{{ wordpress_php_version }}-fpm"
         enabled: true
         state: started
         daemon_reload: true
 
     - name: Verify PHP installation
-      command: "php{{ wordpress_php_version }} --version"
+      ansible.builtin.command: "php{{ wordpress_php_version }} --version"
       register: php_version
       changed_when: false
 
     - name: Check PHP-FPM service status
-      systemd:
+      ansible.builtin.systemd:
         name: "php{{ wordpress_php_version }}-fpm"
         state: started
       register: php_fmp_status
 
     - name: Display test results
-      debug:
+      ansible.builtin.debug:
         msg:
           - "✅ PHP {{ wordpress_php_version }} installation completed!"
           - "✅ PHP version: {{ php_version.stdout.split('\\n')[0] }}"

--- a/test-2-php.yml
+++ b/test-2-php.yml
@@ -29,29 +29,29 @@
 
   tasks:
     - name: Install Prerequisites
-      include_tasks: tasks/prerequisites.yml
+      ansible.builtin.include_tasks: tasks/prerequisites.yml
 
     - name: Install PHP
-      include_tasks: tasks/php.yml
+      ansible.builtin.include_tasks: tasks/php.yml
 
     - name: Verify PHP installation
-      command: php{{ wordpress_php_version }} --version
+      ansible.builtin.command: php{{ wordpress_php_version }} --version
       register: php_version
       changed_when: false
 
     - name: Check PHP-FPM service status
-      systemd:
+      ansible.builtin.systemd:
         name: "{{ wordpress_php_fpm_service }}"
         state: started
       register: php_fpm_status
 
     - name: Verify PHP extensions
-      command: php{{ wordpress_php_version }} -m
+      ansible.builtin.command: php{{ wordpress_php_version }} -m
       register: php_modules
       changed_when: false
 
     - name: Display PHP test results
-      debug:
+      ansible.builtin.debug:
         msg:
           - "✅ PHP {{ wordpress_php_version }} installation completed!"
           - "✅ PHP version: {{ php_version.stdout.split('\n')[0] }}"

--- a/test-3-complete.yml
+++ b/test-3-complete.yml
@@ -53,19 +53,19 @@
 
   tasks:
     - name: Test external database connectivity
-      wait_for:
+      ansible.builtin.wait_for:
         host: "{{ wordpress_db_host }}"
         port: "{{ wordpress_db_port }}"
         timeout: 30
 
     - name: Install prerequisites
-      include_tasks: tasks/prerequisites.yml
+      ansible.builtin.include_tasks: tasks/prerequisites.yml
 
     - name: Install WordPress
-      include_tasks: tasks/wordpress_install.yml
+      ansible.builtin.include_tasks: tasks/wordpress_install.yml
 
     - name: Download latest WordPress (simplified)
-      get_url:
+      ansible.builtin.get_url:
         url: "https://wordpress.org/latest.tar.gz"
         dest: "/tmp/wordpress.tar.gz"
         mode: '0644'
@@ -73,13 +73,13 @@
       register: wp_download
 
     - name: Extract WordPress
-      unarchive:
+      ansible.builtin.unarchive:
         src: "/tmp/wordpress.tar.gz"
         dest: "/tmp"
         remote_src: true
 
     - name: Copy WordPress files
-      copy:
+      ansible.builtin.copy:
         src: "/tmp/wordpress/"
         dest: "{{ wordpress_install_dir }}/"
         remote_src: true
@@ -88,7 +88,7 @@
         mode: preserve
 
     - name: Create wp-config.php from template
-      template:
+      ansible.builtin.template:
         src: wp-config.php.j2
         dest: "{{ wordpress_install_dir }}/wp-config.php"
         owner: "{{ wordpress_system_user }}"
@@ -96,7 +96,7 @@
         mode: '0600'
 
     - name: Verify WordPress files exist
-      stat:
+      ansible.builtin.stat:
         path: "{{ item }}"
       loop:
         - "{{ wordpress_install_dir }}/wp-config.php"
@@ -105,7 +105,7 @@
       register: wp_files_check
 
     - name: Display WordPress installation results
-      debug:
+      ansible.builtin.debug:
         msg:
           - "✅ Complete WordPress installation test completed!"
           - "✅ WordPress downloaded and extracted"

--- a/test-4-verify.yml
+++ b/test-4-verify.yml
@@ -44,35 +44,35 @@
 
   tasks:
     - name: Test external database connectivity
-      wait_for:
+      ansible.builtin.wait_for:
         host: "{{ wordpress_db_host }}"
         port: "{{ wordpress_db_port }}"
         timeout: 10
 
     - name: Install prerequisites
-      include_tasks: tasks/prerequisites.yml
+      ansible.builtin.include_tasks: tasks/prerequisites.yml
 
     - name: Install and configure PHP
-      include_tasks: tasks/php.yml
+      ansible.builtin.include_tasks: tasks/php.yml
 
     - name: Install and configure web server
-      include_tasks: tasks/webserver.yml
+      ansible.builtin.include_tasks: tasks/webserver.yml
 
     - name: Install WordPress
-      include_tasks: tasks/wordpress_install.yml
+      ansible.builtin.include_tasks: tasks/wordpress_install.yml
 
     - name: Configure WordPress
-      include_tasks: tasks/wordpress_config.yml
+      ansible.builtin.include_tasks: tasks/wordpress_config.yml
 
     - name: Verify WordPress Installation
       block:
         - name: Check WordPress directory exists
-          stat:
+          ansible.builtin.stat:
             path: "{{ wordpress_install_dir }}"
           register: wp_dir
 
         - name: Verify WordPress directory exists
-          assert:
+          ansible.builtin.assert:
             that:
               - wp_dir.stat.exists
               - wp_dir.stat.isdir
@@ -80,7 +80,7 @@
             success_msg: "WordPress directory exists"
 
         - name: Check for WordPress core files
-          stat:
+          ansible.builtin.stat:
             path: "{{ wordpress_install_dir }}/{{ item }}"
           register: wp_files
           loop:
@@ -91,7 +91,7 @@
             - wp-blog-header.php
 
         - name: Verify WordPress core files exist
-          assert:
+          ansible.builtin.assert:
             that:
               - item.stat.exists
             fail_msg: "WordPress core file {{ item.item }} is missing"
@@ -99,7 +99,7 @@
           loop: "{{ wp_files.results }}"
 
         - name: Check WordPress directories
-          stat:
+          ansible.builtin.stat:
             path: "{{ wordpress_install_dir }}/{{ item }}"
           register: wp_dirs
           loop:
@@ -108,7 +108,7 @@
             - wp-admin
 
         - name: Verify WordPress directories exist
-          assert:
+          ansible.builtin.assert:
             that:
               - item.stat.exists
               - item.stat.isdir
@@ -117,12 +117,12 @@
           loop: "{{ wp_dirs.results }}"
 
         - name: Check file ownership
-          stat:
+          ansible.builtin.stat:
             path: "{{ wordpress_install_dir }}/index.php"
           register: wp_ownership
 
         - name: Verify file ownership
-          assert:
+          ansible.builtin.assert:
             that:
               - wp_ownership.stat.pw_name == "www-data"
               - wp_ownership.stat.gr_name == "www-data"
@@ -130,7 +130,7 @@
             success_msg: "WordPress files have correct ownership"
 
         - name: Display installation summary
-          debug:
+          ansible.builtin.debug:
             msg:
               - "WordPress installation completed successfully!"
               - "Installation directory: {{ wordpress_install_dir }}"
@@ -140,17 +140,17 @@
               - "PHP version: {{ wordpress_php_version }}"
 
         - name: List installed WordPress files (sample)
-          find:
+          ansible.builtin.find:
             paths: "{{ wordpress_install_dir }}"
             patterns: "wp-*.php"
           register: wp_core_files
 
         - name: Show WordPress core files
-          debug:
+          ansible.builtin.debug:
             msg: "Found {{ wp_core_files.files | length }} WordPress core PHP files"
 
         - name: Check wp-config.php content
-          lineinfile:
+          ansible.builtin.lineinfile:
             path: "{{ wordpress_install_dir }}/wp-config.php"
             line: "define( 'DB_NAME', '{{ wordpress_db_name }}' );"
             state: present
@@ -158,7 +158,7 @@
           register: wp_config_check
 
         - name: Verify wp-config.php is properly configured
-          assert:
+          ansible.builtin.assert:
             that:
               - not wp_config_check.changed
             fail_msg: "wp-config.php is not properly configured with database settings"

--- a/test-5-minimal.yml
+++ b/test-5-minimal.yml
@@ -48,26 +48,26 @@
 
   tasks:
     - name: Test external database connectivity
-      wait_for:
+      ansible.builtin.wait_for:
         host: "{{ wordpress_db_host }}"
         port: "{{ wordpress_db_port }}"
         timeout: 10
 
     - name: Install prerequisites only
-      include_tasks: tasks/prerequisites.yml
+      ansible.builtin.include_tasks: tasks/prerequisites.yml
 
     - name: Install WordPress only
-      include_tasks: tasks/wordpress_install.yml
+      ansible.builtin.include_tasks: tasks/wordpress_install.yml
 
     - name: Verify WordPress Installation
       block:
         - name: Check WordPress directory exists
-          stat:
+          ansible.builtin.stat:
             path: "{{ wordpress_install_dir }}"
           register: wp_dir
 
         - name: Verify WordPress directory exists
-          assert:
+          ansible.builtin.assert:
             that:
               - wp_dir.stat.exists
               - wp_dir.stat.isdir
@@ -75,7 +75,7 @@
             success_msg: "WordPress directory exists: {{ wordpress_install_dir }}"
 
         - name: Check for WordPress core files
-          stat:
+          ansible.builtin.stat:
             path: "{{ wordpress_install_dir }}/{{ item }}"
           register: wp_files
           loop:
@@ -85,7 +85,7 @@
             - wp-blog-header.php
 
         - name: Verify WordPress core files exist
-          assert:
+          ansible.builtin.assert:
             that:
               - item.stat.exists
             fail_msg: "WordPress core file {{ item.item }} is missing"
@@ -93,7 +93,7 @@
           loop: "{{ wp_files.results }}"
 
         - name: Check WordPress directories
-          stat:
+          ansible.builtin.stat:
             path: "{{ wordpress_install_dir }}/{{ item }}"
           register: wp_dirs
           loop:
@@ -102,7 +102,7 @@
             - wp-admin
 
         - name: Verify WordPress directories exist
-          assert:
+          ansible.builtin.assert:
             that:
               - item.stat.exists
               - item.stat.isdir
@@ -111,13 +111,13 @@
           loop: "{{ wp_dirs.results }}"
 
         - name: Count WordPress PHP files
-          find:
+          ansible.builtin.find:
             paths: "{{ wordpress_install_dir }}"
             patterns: "*.php"
           register: wp_php_files
 
         - name: Display installation summary
-          debug:
+          ansible.builtin.debug:
             msg:
               - "=== WordPress Installation Test Results ==="
               - "✓ WordPress directory: {{ wordpress_install_dir }}"

--- a/test-docker.yml
+++ b/test-docker.yml
@@ -58,14 +58,14 @@
 
   tasks:
     - name: Test database connectivity
-      wait_for:
+      ansible.builtin.wait_for:
         host: "{{ wordpress_db_host }}"
         port: "{{ wordpress_db_port }}"
         timeout: 30
       when: wordpress_use_external_db | default(false) | bool
 
     - name: Test Redis connectivity
-      wait_for:
+      ansible.builtin.wait_for:
         host: "{{ wordpress_redis_host }}"
         port: "{{ wordpress_redis_port }}"
         timeout: 30
@@ -77,7 +77,7 @@
 
   post_tasks:
     - name: Display WordPress site information
-      debug:
+      ansible.builtin.debug:
         msg:
           - "WordPress installation completed!"
           - "Site URL: {{ wordpress_site_url }}"

--- a/tests/scenarios/01-basic-installation.yml
+++ b/tests/scenarios/01-basic-installation.yml
@@ -94,7 +94,7 @@
 
   post_tasks:
     - name: Wait for services to be ready
-      wait_for:
+      ansible.builtin.wait_for:
         port: "{{ wordpress_http_port }}"
         host: "{{ ansible_default_ipv4.address }}"
         delay: 10
@@ -110,7 +110,7 @@
       register: wp_response
 
     - name: Display test results
-      debug:
+      ansible.builtin.debug:
         msg:
           - "✅ WordPress installation test completed"
           - "✅ Site accessible at: http://{{ ansible_default_ipv4.address }}"

--- a/tests/scenarios/02-apache-installation.yml
+++ b/tests/scenarios/02-apache-installation.yml
@@ -114,7 +114,7 @@
 
   post_tasks:
     - name: Wait for Apache to be ready
-      wait_for:
+      ansible.builtin.wait_for:
         port: "{{ wordpress_http_port }}"
         host: "{{ ansible_default_ipv4.address }}"
         delay: 15
@@ -149,7 +149,7 @@
       ignore_errors: true
 
     - name: Display comprehensive test results
-      debug:
+      ansible.builtin.debug:
         msg:
           - "✅ Apache WordPress installation test completed"
           - "✅ Site accessible at: http://{{ ansible_default_ipv4.address }}"

--- a/tests/scenarios/03-validation-security.yml
+++ b/tests/scenarios/03-validation-security.yml
@@ -85,7 +85,7 @@
 
   pre_tasks:
     - name: Test input validation functionality
-      include_tasks: ../tasks/validate.yml
+      ansible.builtin.include_tasks: ../tasks/validate.yml
       tags: validation
 
   roles:
@@ -93,7 +93,7 @@
 
   post_tasks:
     - name: Wait for HTTPS services to be ready
-      wait_for:
+      ansible.builtin.wait_for:
         port: "{{ wordpress_https_port }}"
         host: "{{ ansible_default_ipv4.address }}"
         delay: 20
@@ -147,7 +147,7 @@
       ignore_errors: true
 
     - name: Verify SSL certificate (self-signed)
-      command: >
+      ansible.builtin.command: >
         openssl s_client -connect {{ ansible_default_ipv4.address }}:443
         -servername {{ ansible_default_ipv4.address }} -verify_return_error
       delegate_to: localhost
@@ -156,12 +156,12 @@
       changed_when: false
 
     - name: Check file permissions security
-      stat:
+      ansible.builtin.stat:
         path: "{{ wordpress_install_dir }}/wp-config.php"
       register: wpconfig_perms
 
     - name: Display security test results
-      debug:
+      ansible.builtin.debug:
         msg:
           - "🔒 Security and Validation test completed"
           - "🔒 HTTPS accessible: {{ 'Yes' if https_response.status == 200 else 'Redirect' }}"

--- a/tests/scenarios/05-security-edge-cases.yml
+++ b/tests/scenarios/05-security-edge-cases.yml
@@ -128,7 +128,7 @@
         - name: Create test user with limited privileges
           ansible.builtin.user:
             name: testuser
-            shell: /bin/bash
+            ansible.builtin.shell: /bin/bash
             create_home: true
 
         - name: Test security status script as non-root user


### PR DESCRIPTION
## Summary
- Removes duplicate handlers in `handlers/main.yml` and adds safe defaults for service variables
- Adds `no_log: true` to all database tasks that handle passwords (security hardening)
- Fixes all 64+ FQCN violations by converting bare module names to `ansible.builtin.*`
- Fixes key-order violations in block tasks (`when`/`become` before `block`)
- Fixes Makefile `check-test-prereqs` to accept `docker compose` v2 plugin (not just standalone `docker-compose`)
- Adds `pull-requests: write` and `issues: write` permissions to security-tests workflow
- Adds documentation comments to `defaults/main.yml` for password configuration

This PR supersedes #23 which had merge conflicts. All changes from #23 are included here, rebased cleanly on current main.

Closes #23

## Test plan
- [ ] CI lint job (yamllint + ansible-lint) passes
- [ ] Security tests workflow has correct permissions
- [ ] No duplicate handlers remain
- [ ] Database tasks with passwords have `no_log: true`
