### PR TITLE
ci(security): fix Security Hardening Tests sudo failure on self-hosted runners

### DIFF
--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -43,8 +43,21 @@ jobs:
 
     - name: Install system dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y jq bc curl
+        missing=""
+        for tool in jq bc curl; do
+          command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
+        done
+        if [ -z "$missing" ]; then
+          echo "jq, bc, curl already present; skipping apt install"
+          exit 0
+        fi
+        if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+          sudo apt-get update
+          sudo apt-get install -y$missing
+        else
+          echo "::error::Missing tools ($missing) and passwordless sudo unavailable on this runner"
+          exit 1
+        fi
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -43,19 +43,19 @@ jobs:
 
     - name: Install system dependencies
       run: |
-        missing=""
+        missing=()
         for tool in jq bc curl; do
-          command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
+          command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
         done
-        if [ -z "$missing" ]; then
+        if [ "${#missing[@]}" -eq 0 ]; then
           echo "jq, bc, curl already present; skipping apt install"
           exit 0
         fi
-        if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+        if command -v apt-get >/dev/null 2>&1 && command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
           sudo apt-get update
-          sudo apt-get install -y$missing
+          sudo apt-get install -y "${missing[@]}"
         else
-          echo "::error::Missing tools ($missing) and passwordless sudo unavailable on this runner"
+          echo "::error::Missing tools (${missing[*]}) and apt-get/passwordless sudo unavailable on this runner"
           exit 1
         fi
 


### PR DESCRIPTION
The Security Hardening Tests job dies at the 'Install system dependencies' step:

    sudo: a terminal is required to read the password
    sudo: a password is required

The self-hosted runners lack passwordless sudo, but they already have jq, bc, and curl (the coverage step uses them). The step now skips apt when the tools are present and only attempts sudo when passwordless sudo is available, failing with a clear message otherwise. No security test is altered or skipped.

This does not make Lint pass; main has pre-existing ansible-lint debt tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced system dependency installation in security testing workflows with conditional checks, improving reliability and robustness of the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->