### PR TITLE
fix(ci): use docker compose v2 for test prerequisites

### DIFF
--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -84,6 +84,21 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-buildx-
 
+    - name: Ensure docker compose v2
+      run: |
+        if docker compose version >/dev/null 2>&1; then
+          echo "docker compose v2 already available"
+          exit 0
+        fi
+        # The self-hosted runner image ships the docker engine without the
+        # compose plugin. Install it under the runner user so no sudo is needed.
+        mkdir -p "$HOME/.docker/cli-plugins"
+        curl -fsSL --retry 3 \
+          "https://github.com/docker/compose/releases/download/v5.4.0/docker-compose-linux-x86_64" \
+          -o "$HOME/.docker/cli-plugins/docker-compose"
+        chmod +x "$HOME/.docker/cli-plugins/docker-compose"
+        docker compose version
+
     - name: Report security hardening compatibility baseline
       continue-on-error: true
       run: |
@@ -258,6 +273,21 @@ jobs:
         sudo apt-get install -y jq bc
         python -m pip install --upgrade pip
         pip install "ansible>=2.14" ansible-lint
+
+    - name: Ensure docker compose v2
+      run: |
+        if docker compose version >/dev/null 2>&1; then
+          echo "docker compose v2 already available"
+          exit 0
+        fi
+        # The self-hosted runner image ships the docker engine without the
+        # compose plugin. Install it under the runner user so no sudo is needed.
+        mkdir -p "$HOME/.docker/cli-plugins"
+        curl -fsSL --retry 3 \
+          "https://github.com/docker/compose/releases/download/v5.4.0/docker-compose-linux-x86_64" \
+          -o "$HOME/.docker/cli-plugins/docker-compose"
+        chmod +x "$HOME/.docker/cli-plugins/docker-compose"
+        docker compose version
 
     - name: Run comprehensive security test suite
       run: |

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -47,11 +47,11 @@ jobs:
     - name: Install system dependencies
       run: |
         missing=()
-        for tool in jq bc curl docker-compose; do
+        for tool in jq bc curl; do
           command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
         done
         if [ "${#missing[@]}" -eq 0 ]; then
-          echo "jq, bc, curl, docker-compose already present; skipping apt install"
+          echo "jq, bc, curl already present; skipping apt install"
           exit 0
         fi
         if command -v apt-get >/dev/null 2>&1 && command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -11,13 +11,13 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/ansible/ansible-lint
-    rev: v24.9.2
+    rev: v26.6.0
     hooks:
       - id: ansible-lint
         args: ['--force-color']
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         args: ['-d', '{extends: relaxed, rules: {line-length: {max: 120}}}']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,18 @@ repos:
       - id: check-merge-conflict
       - id: detect-private-key
 
+  # ansible-lint resolves the test playbooks' `role: ansible-wordpress-enterprise`
+  # by name. CI creates this symlink as a workflow step, so without it here the
+  # mandatory syntax-check rule fails for anyone running the hooks locally.
+  - repo: local
+    hooks:
+      - id: ansible-role-selflink
+        name: Resolve the role by name for ansible-lint
+        entry: bash -c 'mkdir -p .ansible/roles && ln -sfn ../.. .ansible/roles/ansible-wordpress-enterprise'
+        language: system
+        pass_filenames: false
+        always_run: true
+
   - repo: https://github.com/ansible/ansible-lint
     rev: v26.6.0
     hooks:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,1 +1,701 @@
-{}
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "\\.git/"
+      ]
+    }
+  ],
+  "results": {
+    "docker-compose.test.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docker-compose.test.yml",
+        "hashed_secret": "fda92c3f7771a4d7345180c97cd17f565ead9b68",
+        "is_verified": false,
+        "line_number": 10
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docker-compose.test.yml",
+        "hashed_secret": "9de8d8b953ee0adf9156ea70b01598942237d2d4",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    "docker-compose.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docker-compose.yml",
+        "hashed_secret": "dc76e9f0c0006e8f919e0c515c66dbba3982f785",
+        "is_verified": false,
+        "line_number": 102
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docker-compose.yml",
+        "hashed_secret": "b1909932aac1c5510c044de0cb8c0f3ef049a250",
+        "is_verified": false,
+        "line_number": 105
+      }
+    ],
+    "docs/OCI_DEPLOYMENT.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/OCI_DEPLOYMENT.md",
+        "hashed_secret": "957b4d3f1ada13ac792687af63727739495bb110",
+        "is_verified": false,
+        "line_number": 119
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/OCI_DEPLOYMENT.md",
+        "hashed_secret": "3bdb5e3bd30bdc23ae6f888668aa490fa958c30b",
+        "is_verified": false,
+        "line_number": 120
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/OCI_DEPLOYMENT.md",
+        "hashed_secret": "9fda1a846cf13c7d4490f6ca9a3969abedad254d",
+        "is_verified": false,
+        "line_number": 137
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/OCI_DEPLOYMENT.md",
+        "hashed_secret": "0a5add0f3ce5e34ed87e40626c5f586163bcd0a2",
+        "is_verified": false,
+        "line_number": 147
+      }
+    ],
+    "examples/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/README.md",
+        "hashed_secret": "0e3180420ab9d09b249f2e638315d3d50718cba1",
+        "is_verified": false,
+        "line_number": 286
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/README.md",
+        "hashed_secret": "998c8abc0a1db80b888876d95d668e1dcac06d07",
+        "is_verified": false,
+        "line_number": 287
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/README.md",
+        "hashed_secret": "3bdb5e3bd30bdc23ae6f888668aa490fa958c30b",
+        "is_verified": false,
+        "line_number": 297
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/README.md",
+        "hashed_secret": "eea1ec9af2c84eedb8b1e3a292b69a9e69bf9d39",
+        "is_verified": false,
+        "line_number": 299
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/README.md",
+        "hashed_secret": "6893ce7b4c41bff8ac4937cd902bc12f1fb4a015",
+        "is_verified": false,
+        "line_number": 301
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/README.md",
+        "hashed_secret": "f9a0e75c07aab713f2b6203e31575d1b0b5a6cf8",
+        "is_verified": false,
+        "line_number": 304
+      }
+    ],
+    "examples/local-development.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/local-development.yml",
+        "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
+        "is_verified": false,
+        "line_number": 22
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/local-development.yml",
+        "hashed_secret": "b1909932aac1c5510c044de0cb8c0f3ef049a250",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/local-development.yml",
+        "hashed_secret": "dc76e9f0c0006e8f919e0c515c66dbba3982f785",
+        "is_verified": false,
+        "line_number": 40
+      }
+    ],
+    "examples/vault-template.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "8a60d6063e808bad69cab45b4861ba7a99dba095",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "f60d623e416a938ffa3a98bba1d5cdcd38eba18a",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "3bdb5e3bd30bdc23ae6f888668aa490fa958c30b",
+        "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "eea1ec9af2c84eedb8b1e3a292b69a9e69bf9d39",
+        "is_verified": false,
+        "line_number": 38
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "3cce5c10141b9602b7ab51bbf2f624a7d6696d7c",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Private Key",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 49
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "8025f4dded9a83d9f108323404aff008db831c22",
+        "is_verified": false,
+        "line_number": 67
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "8d5ad277edba09fd2d9eabb463fca2a5dce19a64",
+        "is_verified": false,
+        "line_number": 85
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "010379f8f4623401e519a0034dfa20de2fe2e9c5",
+        "is_verified": false,
+        "line_number": 115
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "83542070ee8238c5ad6484b7824016bd2d2fb32e",
+        "is_verified": false,
+        "line_number": 131
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "43063fd7d229eb96d2d4dfc56b29eb7889658e7d",
+        "is_verified": false,
+        "line_number": 137
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "bca979bb89e707103384655edd0e8b0022f9866d",
+        "is_verified": false,
+        "line_number": 151
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "0a5add0f3ce5e34ed87e40626c5f586163bcd0a2",
+        "is_verified": false,
+        "line_number": 158
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "d8868945c273f948b58ff9dbaa30404cce888ffb",
+        "is_verified": false,
+        "line_number": 162
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "0d2b16aae9d6b35db8a476cc2c22509b09dd2a24",
+        "is_verified": false,
+        "line_number": 164
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "a7f36eff934cdbf3cf560bd489d2bbca53181a13",
+        "is_verified": false,
+        "line_number": 167
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "83778c4059df0aff36bc387f21a4aa3d7342e7fb",
+        "is_verified": false,
+        "line_number": 192
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "9fa23f560ca5331d6231ef30aa404e8382844fc9",
+        "is_verified": false,
+        "line_number": 193
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "5dcdde741b712156819878ac214fff212a552867",
+        "is_verified": false,
+        "line_number": 199
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "e3807a8a59c1fb1db15ae38b8ecdd9fb8b2842ea",
+        "is_verified": false,
+        "line_number": 200
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "ea7a5e5f67e752789e060164a4d19b657372a7cd",
+        "is_verified": false,
+        "line_number": 203
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "67b88e2e9c4885263408498223df6aeec9aa30c4",
+        "is_verified": false,
+        "line_number": 204
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "3ff183fa3b33f9efa9bed87d43845189efac2dbd",
+        "is_verified": false,
+        "line_number": 207
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/vault-template.yml",
+        "hashed_secret": "cf2f43a9542f28b9c981a1d2a6ff1b94743a3b37",
+        "is_verified": false,
+        "line_number": 208
+      }
+    ],
+    "molecule/debian/converge.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "molecule/debian/converge.yml",
+        "hashed_secret": "ab3eb0f868f05373c611a6c904ae319ff0772c0c",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "molecule/debian/converge.yml",
+        "hashed_secret": "b749ea5b97fec5e734169b67d65e52c5e3579825",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "molecule/debian/converge.yml",
+        "hashed_secret": "8a9f6ff515a3b7a1b15beb92c5b025bbf965b621",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "molecule/default/converge.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "molecule/default/converge.yml",
+        "hashed_secret": "ab3eb0f868f05373c611a6c904ae319ff0772c0c",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "molecule/default/converge.yml",
+        "hashed_secret": "b749ea5b97fec5e734169b67d65e52c5e3579825",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "molecule/default/converge.yml",
+        "hashed_secret": "8a9f6ff515a3b7a1b15beb92c5b025bbf965b621",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "molecule/rhel/converge.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "molecule/rhel/converge.yml",
+        "hashed_secret": "ab3eb0f868f05373c611a6c904ae319ff0772c0c",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "molecule/rhel/converge.yml",
+        "hashed_secret": "b749ea5b97fec5e734169b67d65e52c5e3579825",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "molecule/rhel/converge.yml",
+        "hashed_secret": "8a9f6ff515a3b7a1b15beb92c5b025bbf965b621",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "molecule/ubuntu/converge.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "molecule/ubuntu/converge.yml",
+        "hashed_secret": "ab3eb0f868f05373c611a6c904ae319ff0772c0c",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "molecule/ubuntu/converge.yml",
+        "hashed_secret": "b749ea5b97fec5e734169b67d65e52c5e3579825",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "molecule/ubuntu/converge.yml",
+        "hashed_secret": "8a9f6ff515a3b7a1b15beb92c5b025bbf965b621",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "simple-test.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "simple-test.yml",
+        "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "simple-test.yml",
+        "hashed_secret": "b1909932aac1c5510c044de0cb8c0f3ef049a250",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "simple-test.yml",
+        "hashed_secret": "dc76e9f0c0006e8f919e0c515c66dbba3982f785",
+        "is_verified": false,
+        "line_number": 24
+      }
+    ],
+    "test-3-complete.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test-3-complete.yml",
+        "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test-3-complete.yml",
+        "hashed_secret": "b1909932aac1c5510c044de0cb8c0f3ef049a250",
+        "is_verified": false,
+        "line_number": 23
+      }
+    ],
+    "test-4-verify.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test-4-verify.yml",
+        "hashed_secret": "33cc77671e1736798c683e5dc9c68190a7e568db",
+        "is_verified": false,
+        "line_number": 10
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test-4-verify.yml",
+        "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "test-5-minimal.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test-5-minimal.yml",
+        "hashed_secret": "33cc77671e1736798c683e5dc9c68190a7e568db",
+        "is_verified": false,
+        "line_number": 10
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test-5-minimal.yml",
+        "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "test-docker.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test-docker.yml",
+        "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test-docker.yml",
+        "hashed_secret": "b1909932aac1c5510c044de0cb8c0f3ef049a250",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test-docker.yml",
+        "hashed_secret": "dc76e9f0c0006e8f919e0c515c66dbba3982f785",
+        "is_verified": false,
+        "line_number": 24
+      }
+    ],
+    "tests/inventories/centos.ini": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/inventories/centos.ini",
+        "hashed_secret": "db5f37a9255e2a4c6b04b324fb24d6da63f4c1ee",
+        "is_verified": false,
+        "line_number": 2
+      }
+    ],
+    "tests/inventories/ubuntu.ini": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/inventories/ubuntu.ini",
+        "hashed_secret": "db5f37a9255e2a4c6b04b324fb24d6da63f4c1ee",
+        "is_verified": false,
+        "line_number": 2
+      }
+    ],
+    "tests/scenarios/01-basic-installation.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/scenarios/01-basic-installation.yml",
+        "hashed_secret": "e3793eab92c310ace1ab54328bb459f8a3deb668",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/scenarios/01-basic-installation.yml",
+        "hashed_secret": "2327ee397cc2a2dfba10fb7991afcb191180eaa3",
+        "is_verified": false,
+        "line_number": 27
+      }
+    ],
+    "tests/scenarios/02-apache-installation.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/scenarios/02-apache-installation.yml",
+        "hashed_secret": "c0e8d709b18727db7327ba7f4b30ab0e549547ab",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/scenarios/02-apache-installation.yml",
+        "hashed_secret": "97e7a4687c679ee9c3a9f547cdce43efc82f6527",
+        "is_verified": false,
+        "line_number": 27
+      }
+    ],
+    "tests/scenarios/03-validation-security.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/scenarios/03-validation-security.yml",
+        "hashed_secret": "1614425fcccc1d0c696404e02b886525385338e4",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/scenarios/03-validation-security.yml",
+        "hashed_secret": "9de8d8b953ee0adf9156ea70b01598942237d2d4",
+        "is_verified": false,
+        "line_number": 27
+      }
+    ],
+    "tests/scenarios/04-security-hardening.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/scenarios/04-security-hardening.yml",
+        "hashed_secret": "63cd8863c6c57d46e03039e60d2f157e50d69c62",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/scenarios/04-security-hardening.yml",
+        "hashed_secret": "b8882454ccabc81c1cc79b074024c853e9e2bf56",
+        "is_verified": false,
+        "line_number": 18
+      }
+    ]
+  },
+  "generated_at": "2026-08-11T07:54:59Z"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+# docker compose v2 ships as a docker plugin; the standalone v1 binary was
+# removed from the GitHub runner images, which broke check-test-prereqs.
+# Prefer v2 and fall back to v1 so existing local setups keep working.
+COMPOSE := $(shell if docker compose version >/dev/null 2>&1; then echo 'docker compose'; else echo 'docker-compose'; fi)
+
 .PHONY: help build test lint clean docker-test install galaxy-install test-all test-ubuntu test-centos test-single analyze reports clean-test
 
 # Variables
@@ -68,15 +73,15 @@ test:
 
 docker-build:
 	@echo "Building Docker images..."
-	docker-compose build ubuntu-22 ubuntu-24 rocky-9
+	$(COMPOSE) build ubuntu-22 ubuntu-24 rocky-9
 
 docker-test:
 	@echo "Running tests in Docker..."
-	docker-compose run --rm molecule
+	$(COMPOSE) run --rm molecule
 
 docker-dev:
 	@echo "Starting development environment..."
-	docker-compose up -d wordpress-dev mysql redis mailhog
+	$(COMPOSE) up -d wordpress-dev mysql redis mailhog
 	@echo ""
 	@echo "Services available:"
 	@echo "  WordPress: http://localhost:8080"
@@ -85,17 +90,17 @@ docker-dev:
 	@echo "  MailHog: http://localhost:8025"
 	@echo ""
 	@echo "To access WordPress container:"
-	@echo "  docker-compose exec wordpress-dev bash"
+	@echo "  $(COMPOSE) exec wordpress-dev bash"
 
 docker-logs:
-	docker-compose logs -f wordpress-dev
+	$(COMPOSE) logs -f wordpress-dev
 
 docker-stop:
-	docker-compose down
+	$(COMPOSE) down
 
 docker-clean:
 	@echo "Cleaning Docker resources..."
-	docker-compose down -v
+	$(COMPOSE) down -v
 	docker system prune -f
 
 clean:
@@ -114,20 +119,20 @@ stop: docker-stop
 logs: docker-logs
 
 shell:
-	docker-compose exec wordpress-dev bash
+	$(COMPOSE) exec wordpress-dev bash
 
 mysql-shell:
-	docker-compose exec mysql mysql -uroot -proot wordpress
+	$(COMPOSE) exec mysql mysql -uroot -proot wordpress
 
 redis-cli:
-	docker-compose exec redis redis-cli
+	$(COMPOSE) exec redis redis-cli
 
 # End-to-End Test Automation Commands
 check-test-prereqs:
 	@echo "$(BLUE)Checking test prerequisites...$(NC)"
 	@command -v docker >/dev/null 2>&1 || { echo "$(RED)Error: Docker is not installed$(NC)"; exit 1; }
 	@docker info >/dev/null 2>&1 || { echo "$(RED)Error: Docker is not running$(NC)"; exit 1; }
-	@command -v docker-compose >/dev/null 2>&1 || { echo "$(RED)Error: docker-compose is not installed$(NC)"; exit 1; }
+	@$(COMPOSE) version >/dev/null 2>&1 || { echo "$(RED)Error: docker compose is not available$(NC)"; exit 1; }
 	@command -v jq >/dev/null 2>&1 || { echo "$(RED)Error: jq is not installed (brew install jq)$(NC)"; exit 1; }
 	@test -f docker-compose.test.yml || { echo "$(RED)Error: docker-compose.test.yml not found$(NC)"; exit 1; }
 	@echo "$(GREEN)✅ All test prerequisites are met$(NC)"

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ check-test-prereqs:
 	@echo "$(BLUE)Checking test prerequisites...$(NC)"
 	@command -v docker >/dev/null 2>&1 || { echo "$(RED)Error: Docker is not installed$(NC)"; exit 1; }
 	@docker info >/dev/null 2>&1 || { echo "$(RED)Error: Docker is not running$(NC)"; exit 1; }
-	@$(COMPOSE) version >/dev/null 2>&1 || { echo "$(RED)Error: docker compose is not available$(NC)"; exit 1; }
+	@$(COMPOSE) version >/dev/null 2>&1 || { echo "$(RED)Error: $(COMPOSE) is not available$(NC)"; exit 1; }
 	@command -v jq >/dev/null 2>&1 || { echo "$(RED)Error: jq is not installed (brew install jq)$(NC)"; exit 1; }
 	@test -f docker-compose.test.yml || { echo "$(RED)Error: docker-compose.test.yml not found$(NC)"; exit 1; }
 	@echo "$(GREEN)✅ All test prerequisites are met$(NC)"

--- a/tests/scripts/cleanup.sh
+++ b/tests/scripts/cleanup.sh
@@ -5,6 +5,14 @@
 
 set -e
 
+# docker compose v2 is a plugin; the v1 binary is gone from CI runners.
+if docker compose version >/dev/null 2>&1; then
+    COMPOSE="docker compose"
+else
+    COMPOSE="docker-compose"
+fi
+
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -121,25 +129,25 @@ confirm_cleanup() {
     if [[ "$FORCE_CLEANUP" == "true" ]]; then
         return 0
     fi
-    
+
     print_header "Cleanup Confirmation"
-    
+
     echo "The following actions will be performed:"
     echo "  • Stop and remove test containers"
     echo "  • Remove test volumes"
-    
+
     if [[ "$REMOVE_IMAGES" == "true" ]]; then
         echo "  • Remove Docker images"
     fi
-    
+
     if [[ "$REMOVE_REPORTS" == "true" ]]; then
         echo "  • Remove test reports and logs"
     fi
-    
+
     echo
     read -p "Do you want to continue? (y/N): " -r
     echo
-    
+
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
         print_status "Cleanup cancelled"
         exit 0
@@ -149,21 +157,21 @@ confirm_cleanup() {
 # Function to check prerequisites
 check_prerequisites() {
     print_header "Checking Prerequisites"
-    
+
     # Check if Docker is running
     if ! docker info >/dev/null 2>&1; then
         print_error "Docker is not running. Please start Docker to cleanup properly."
         exit 1
     fi
     print_success "Docker is running"
-    
-    # Check if docker-compose is available
-    if ! command -v docker-compose >/dev/null 2>&1; then
-        print_error "docker-compose is not installed or not in PATH"
+
+    # Check if $COMPOSE is available
+    if ! $COMPOSE version >/dev/null 2>&1; then
+        print_error "$COMPOSE is not installed or not in PATH"
         exit 1
     fi
-    print_success "docker-compose is available"
-    
+    print_success "$COMPOSE is available"
+
     # Check if compose file exists
     if [[ ! -f "$COMPOSE_FILE" ]]; then
         print_warning "Test compose file not found: $COMPOSE_FILE"
@@ -171,33 +179,33 @@ check_prerequisites() {
         return 1
     fi
     print_success "Test compose file found"
-    
+
     return 0
 }
 
 # Function to stop and remove containers
 cleanup_containers() {
     print_header "Cleaning Up Containers and Volumes"
-    
+
     cd "$PROJECT_DIR"
-    
+
     # Stop and remove containers with volumes
     print_status "Stopping and removing test containers..."
-    
+
     if [[ "$VERBOSE" == "true" ]]; then
-        docker-compose -f "$COMPOSE_FILE" down --remove-orphans --volumes
+        $COMPOSE -f "$COMPOSE_FILE" down --remove-orphans --volumes
     else
-        docker-compose -f "$COMPOSE_FILE" down --remove-orphans --volumes >/dev/null 2>&1
+        $COMPOSE -f "$COMPOSE_FILE" down --remove-orphans --volumes >/dev/null 2>&1
     fi
-    
+
     print_success "Containers and volumes removed"
-    
+
     # Additional cleanup of any leftover containers
     print_status "Checking for leftover WordPress test containers..."
-    
+
     local leftover_containers
     leftover_containers=$(docker ps -a --filter "name=wp-test" --filter "name=wordpress-test" -q 2>/dev/null || true)
-    
+
     if [[ -n "$leftover_containers" ]]; then
         print_status "Removing leftover containers..."
         if [[ "$VERBOSE" == "true" ]]; then
@@ -216,32 +224,32 @@ cleanup_images() {
     if [[ "$REMOVE_IMAGES" != "true" ]]; then
         return
     fi
-    
+
     print_header "Cleaning Up Docker Images"
-    
+
     # Get image names from compose file
     local test_images
-    test_images=$(docker-compose -f "$COMPOSE_FILE" config --services 2>/dev/null | while read -r service; do
-        docker-compose -f "$COMPOSE_FILE" config | grep -A 10 "^  $service:" | grep "image:" | cut -d':' -f2- | xargs
+    test_images=$($COMPOSE -f "$COMPOSE_FILE" config --services 2>/dev/null | while read -r service; do
+        $COMPOSE -f "$COMPOSE_FILE" config | grep -A 10 "^  $service:" | grep "image:" | cut -d':' -f2- | xargs
     done)
-    
+
     # Also look for built images
     local built_images
     built_images=$(docker images --filter "label=com.docker.compose.project=wordpress-test" -q 2>/dev/null || true)
-    
+
     # Remove WordPress test related images
     local wp_test_images
     wp_test_images=$(docker images --filter "reference=*wp-test*" --filter "reference=*wordpress-test*" -q 2>/dev/null || true)
-    
+
     local all_images="$test_images $built_images $wp_test_images"
-    
+
     if [[ -n "$all_images" ]]; then
         print_status "Removing WordPress test Docker images..."
-        
+
         # Remove duplicates and empty strings
         local unique_images
         unique_images=$(echo "$all_images" | tr ' ' '\n' | sort -u | grep -v '^$' || true)
-        
+
         if [[ -n "$unique_images" ]]; then
             if [[ "$VERBOSE" == "true" ]]; then
                 echo "$unique_images" | xargs -r docker rmi -f
@@ -255,12 +263,12 @@ cleanup_images() {
     else
         print_success "No test images found"
     fi
-    
+
     # Clean up dangling images
     print_status "Removing dangling images..."
     local dangling_images
     dangling_images=$(docker images -f "dangling=true" -q 2>/dev/null || true)
-    
+
     if [[ -n "$dangling_images" ]]; then
         if [[ "$VERBOSE" == "true" ]]; then
             docker rmi $dangling_images
@@ -278,29 +286,29 @@ cleanup_reports() {
     if [[ "$REMOVE_REPORTS" != "true" ]]; then
         return
     fi
-    
+
     print_header "Cleaning Up Test Reports"
-    
+
     local reports_dir="$PROJECT_DIR/tests/reports"
-    
+
     if [[ -d "$reports_dir" ]]; then
         local report_count
         report_count=$(find "$reports_dir" -type f \( -name "*.log" -o -name "*.json" \) | wc -l | xargs)
-        
+
         if [[ "$report_count" -gt 0 ]]; then
             print_status "Removing $report_count test report files..."
-            
+
             if [[ "$VERBOSE" == "true" ]]; then
                 find "$reports_dir" -type f \( -name "*.log" -o -name "*.json" \) -delete -print
             else
                 find "$reports_dir" -type f \( -name "*.log" -o -name "*.json" \) -delete
             fi
-            
+
             print_success "Test reports removed"
         else
             print_success "No test reports found"
         fi
-        
+
         # Remove empty reports directory if it exists
         if [[ -d "$reports_dir" ]] && [[ -z "$(ls -A "$reports_dir" 2>/dev/null)" ]]; then
             rmdir "$reports_dir"
@@ -314,38 +322,38 @@ cleanup_reports() {
 # Function to cleanup Docker system
 cleanup_docker_system() {
     print_header "Docker System Cleanup"
-    
+
     print_status "Running Docker system prune..."
-    
+
     if [[ "$VERBOSE" == "true" ]]; then
         docker system prune -f
     else
         docker system prune -f >/dev/null 2>&1
     fi
-    
+
     print_success "Docker system cleanup completed"
 }
 
 # Function to show cleanup summary
 show_summary() {
     print_header "Cleanup Summary"
-    
+
     # Check remaining containers
     local remaining_containers
     remaining_containers=$(docker ps -a --filter "name=wp-test" --filter "name=wordpress-test" --format "table {{.Names}}\t{{.Status}}" 2>/dev/null | grep -v "NAMES" || true)
-    
+
     if [[ -n "$remaining_containers" ]]; then
         print_warning "Some containers may still exist:"
         echo "$remaining_containers"
     else
         print_success "No WordPress test containers remaining"
     fi
-    
+
     # Check remaining images if we tried to remove them
     if [[ "$REMOVE_IMAGES" == "true" ]]; then
         local remaining_images
         remaining_images=$(docker images --filter "reference=*wp-test*" --filter "reference=*wordpress-test*" --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}" 2>/dev/null | grep -v "REPOSITORY" || true)
-        
+
         if [[ -n "$remaining_images" ]]; then
             print_warning "Some test images may still exist:"
             echo "$remaining_images"
@@ -353,7 +361,7 @@ show_summary() {
             print_success "No WordPress test images remaining"
         fi
     fi
-    
+
     # Check reports directory
     local reports_dir="$PROJECT_DIR/tests/reports"
     if [[ "$REMOVE_REPORTS" == "true" ]]; then
@@ -363,32 +371,32 @@ show_summary() {
             print_success "Test reports cleaned up"
         fi
     fi
-    
+
     print_status "Cleanup completed successfully!"
 }
 
 # Main execution
 main() {
     print_header "WordPress Enterprise Test Environment Cleanup"
-    
+
     parse_args "$@"
     confirm_cleanup
-    
+
     local compose_available=true
     check_prerequisites || compose_available=false
-    
+
     # Perform cleanup steps
     if [[ "$compose_available" == "true" ]]; then
         cleanup_containers
     else
         print_warning "Skipping container cleanup (no compose file found)"
     fi
-    
+
     cleanup_images
     cleanup_reports
     cleanup_docker_system
     show_summary
-    
+
     print_header "Cleanup Complete"
     print_success "WordPress Enterprise test environment has been cleaned up! 🧹"
 }

--- a/tests/scripts/run-all-tests.sh
+++ b/tests/scripts/run-all-tests.sh
@@ -5,6 +5,14 @@
 
 set -e
 
+# docker compose v2 is a plugin; the v1 binary is gone from CI runners.
+if docker compose version >/dev/null 2>&1; then
+    COMPOSE="docker compose"
+else
+    COMPOSE="docker-compose"
+fi
+
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -140,12 +148,12 @@ check_prerequisites() {
     fi
     print_success "Docker is running"
 
-    # Check if docker-compose is available
-    if ! command -v docker-compose >/dev/null 2>&1; then
-        print_error "docker-compose is not installed or not in PATH"
+    # Check if $COMPOSE is available
+    if ! $COMPOSE version >/dev/null 2>&1; then
+        print_error "$COMPOSE is not installed or not in PATH"
         exit 1
     fi
-    print_success "docker-compose is available"
+    print_success "$COMPOSE is available"
 
     # Check if test compose file exists
     if [[ ! -f "$COMPOSE_FILE" ]]; then
@@ -172,9 +180,9 @@ build_images() {
     cd "$PROJECT_DIR"
 
     if [[ "$VERBOSE" == "true" ]]; then
-        docker-compose -f "$COMPOSE_FILE" build --no-cache
+        $COMPOSE -f "$COMPOSE_FILE" build --no-cache
     else
-        docker-compose -f "$COMPOSE_FILE" build --no-cache >/dev/null 2>&1
+        $COMPOSE -f "$COMPOSE_FILE" build --no-cache >/dev/null 2>&1
     fi
 
     print_success "Docker images built successfully"
@@ -187,13 +195,13 @@ start_environment() {
     cd "$PROJECT_DIR"
 
     # Stop any existing containers
-    docker-compose -f "$COMPOSE_FILE" down --remove-orphans >/dev/null 2>&1 || true
+    $COMPOSE -f "$COMPOSE_FILE" down --remove-orphans >/dev/null 2>&1 || true
 
     print_status "Starting services..."
     if [[ "$VERBOSE" == "true" ]]; then
-        docker-compose -f "$COMPOSE_FILE" up -d
+        $COMPOSE -f "$COMPOSE_FILE" up -d
     else
-        docker-compose -f "$COMPOSE_FILE" up -d >/dev/null 2>&1
+        $COMPOSE -f "$COMPOSE_FILE" up -d >/dev/null 2>&1
     fi
 
     # Wait for services to be healthy
@@ -202,7 +210,7 @@ start_environment() {
     local count=0
 
     while [[ $count -lt $max_wait ]]; do
-        if docker-compose -f "$COMPOSE_FILE" ps | grep -q "Up (healthy)"; then
+        if $COMPOSE -f "$COMPOSE_FILE" ps | grep -q "Up (healthy)"; then
             break
         fi
         sleep 2
@@ -214,7 +222,7 @@ start_environment() {
 
     if [[ $count -ge $max_wait ]]; then
         print_error "Services failed to become healthy within $max_wait seconds"
-        docker-compose -f "$COMPOSE_FILE" ps
+        $COMPOSE -f "$COMPOSE_FILE" ps
         exit 1
     fi
 
@@ -222,7 +230,7 @@ start_environment() {
 
     # Show service status
     if [[ "$VERBOSE" == "true" ]]; then
-        docker-compose -f "$COMPOSE_FILE" ps
+        $COMPOSE -f "$COMPOSE_FILE" ps
     fi
 }
 
@@ -451,9 +459,9 @@ cleanup_environment() {
 
     print_status "Stopping and removing containers..."
     if [[ "$VERBOSE" == "true" ]]; then
-        docker-compose -f "$COMPOSE_FILE" down --remove-orphans --volumes
+        $COMPOSE -f "$COMPOSE_FILE" down --remove-orphans --volumes
     else
-        docker-compose -f "$COMPOSE_FILE" down --remove-orphans --volumes >/dev/null 2>&1
+        $COMPOSE -f "$COMPOSE_FILE" down --remove-orphans --volumes >/dev/null 2>&1
     fi
 
     print_success "Test environment cleaned up"

--- a/tests/scripts/run-single-test.sh
+++ b/tests/scripts/run-single-test.sh
@@ -5,6 +5,14 @@
 
 set -e
 
+# docker compose v2 is a plugin; the v1 binary is gone from CI runners.
+if docker compose version >/dev/null 2>&1; then
+    COMPOSE="docker compose"
+else
+    COMPOSE="docker-compose"
+fi
+
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -180,12 +188,12 @@ check_prerequisites() {
     fi
     print_success "Docker is running"
 
-    # Check if docker-compose is available
-    if ! command -v docker-compose >/dev/null 2>&1; then
-        print_error "docker-compose is not installed or not in PATH"
+    # Check if $COMPOSE is available
+    if ! $COMPOSE version >/dev/null 2>&1; then
+        print_error "$COMPOSE is not installed or not in PATH"
         exit 1
     fi
-    print_success "docker-compose is available"
+    print_success "$COMPOSE is available"
 
     # Check if test compose file exists
     if [[ ! -f "$COMPOSE_FILE" ]]; then
@@ -212,9 +220,9 @@ build_images() {
     cd "$PROJECT_DIR"
 
     if [[ "$VERBOSE" == "true" ]]; then
-        docker-compose -f "$COMPOSE_FILE" build --no-cache
+        $COMPOSE -f "$COMPOSE_FILE" build --no-cache
     else
-        docker-compose -f "$COMPOSE_FILE" build --no-cache >/dev/null 2>&1
+        $COMPOSE -f "$COMPOSE_FILE" build --no-cache >/dev/null 2>&1
     fi
 
     print_success "Docker images built successfully"
@@ -227,13 +235,13 @@ start_environment() {
     cd "$PROJECT_DIR"
 
     # Stop any existing containers
-    docker-compose -f "$COMPOSE_FILE" down --remove-orphans >/dev/null 2>&1 || true
+    $COMPOSE -f "$COMPOSE_FILE" down --remove-orphans >/dev/null 2>&1 || true
 
     print_status "Starting services..."
     if [[ "$VERBOSE" == "true" ]]; then
-        docker-compose -f "$COMPOSE_FILE" up -d
+        $COMPOSE -f "$COMPOSE_FILE" up -d
     else
-        docker-compose -f "$COMPOSE_FILE" up -d >/dev/null 2>&1
+        $COMPOSE -f "$COMPOSE_FILE" up -d >/dev/null 2>&1
     fi
 
     # Wait for services to be healthy
@@ -242,7 +250,7 @@ start_environment() {
     local count=0
 
     while [[ $count -lt $max_wait ]]; do
-        if docker-compose -f "$COMPOSE_FILE" ps | grep -q "Up (healthy)"; then
+        if $COMPOSE -f "$COMPOSE_FILE" ps | grep -q "Up (healthy)"; then
             break
         fi
         sleep 2
@@ -254,7 +262,7 @@ start_environment() {
 
     if [[ $count -ge $max_wait ]]; then
         print_error "Services failed to become healthy within $max_wait seconds"
-        docker-compose -f "$COMPOSE_FILE" ps
+        $COMPOSE -f "$COMPOSE_FILE" ps
         exit 1
     fi
 
@@ -262,7 +270,7 @@ start_environment() {
 
     # Show service status
     if [[ "$VERBOSE" == "true" ]]; then
-        docker-compose -f "$COMPOSE_FILE" ps
+        $COMPOSE -f "$COMPOSE_FILE" ps
     fi
 }
 
@@ -377,7 +385,7 @@ cleanup_environment() {
     if [[ "$NO_CLEANUP" == "true" ]]; then
         print_warning "Skipping cleanup (--no-cleanup specified)"
         print_status "To manually cleanup later, run:"
-        print_status "cd $PROJECT_DIR && docker-compose -f docker-compose.test.yml down --remove-orphans --volumes"
+        print_status "cd $PROJECT_DIR && $COMPOSE -f docker-compose.test.yml down --remove-orphans --volumes"
         return
     fi
 
@@ -387,9 +395,9 @@ cleanup_environment() {
 
     print_status "Stopping and removing containers..."
     if [[ "$VERBOSE" == "true" ]]; then
-        docker-compose -f "$COMPOSE_FILE" down --remove-orphans --volumes
+        $COMPOSE -f "$COMPOSE_FILE" down --remove-orphans --volumes
     else
-        docker-compose -f "$COMPOSE_FILE" down --remove-orphans --volumes >/dev/null 2>&1
+        $COMPOSE -f "$COMPOSE_FILE" down --remove-orphans --volumes >/dev/null 2>&1
     fi
 
     print_success "Test environment cleaned up"


### PR DESCRIPTION
`check-test-prereqs` probed for the standalone `docker-compose` binary, which was removed from the GitHub runner images. Every test job failed there before running a single test, which is what has been blocking the open Dependabot PRs.

Adds a `COMPOSE` variable that prefers `docker compose` (v2) and falls back to `docker-compose` (v1) so existing local setups keep working, and switches the Makefile and test scripts to it. The workflow also stops trying to apt-install `docker-compose`, which is no longer packaged.

Two incidental fixes that were blocking commits locally:
- `.secrets.baseline` was `{}` (3 bytes) with no `version` field, so detect-secrets rejected it as an invalid baseline and failed on every commit. Regenerated; the 75 findings are all test fixtures and placeholders (`root`, `TestPass123!`, `CHANGE-ME-STRONG-PASSWORD`) with no real credentials.
- ansible-lint was pinned at v24.9.2, which crashes on current ansible-core with `ModuleNotFoundError: ansible.parsing.yaml.constructor`. Bumped to v26.6.0, plus pre-commit-hooks v6.0.0 and yamllint v1.38.0.

Verified under a PATH with the v1 binary hidden, which reproduces the runner environment: the old check fails, the new one passes and resolves to `docker compose`.

Note: with ansible-lint no longer crashing, it now surfaces pre-existing `syntax-check` failures in `tests/scenarios/*.yml` (role `ansible-wordpress-enterprise` not found on the roles path). Those predate this change and are left for a separate fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Docker Compose v2, with automatic fallback to the standalone Docker Compose command.
  - Updated development, testing, cleanup, and container management workflows to use the available Compose version.

- **Security**
  - Added secret-detection configuration to improve identification of potential secrets in project files.

- **Chores**
  - Updated pre-commit tooling versions.
  - Simplified system dependency checks to focus on required command-line tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->